### PR TITLE
Battle Rage prompt update

### DIFF
--- a/TReX_serverside.lua
+++ b/TReX_serverside.lua
@@ -1125,6 +1125,18 @@ function TReX.serverside.myShin()
  end
 end
 
+
+function TReX.serverside.myRage()
+ if gmcp.Char.Vitals then
+	for k, v in pairs(gmcp.Char.Vitals.charstats) do
+		if string.starts(v, "Rage") then
+			trex_rage = tonumber(string.match(v,"Rage: (%d+)"))
+			return  trex_rage
+		end
+	end
+ end
+end
+
 -- affliction table list echo
 t.serverside.gmcpAffShow=function()  -- this is your aff display
 

--- a/TReX_stats.lua
+++ b/TReX_stats.lua
@@ -17,7 +17,8 @@ TReX.stats.prompt_options={
 	willpower = function () return TReX.stats.willpower_color_percentage(math.floor(TReX.stats.w*100/TReX.stats.maxw))..tostring(TReX.stats.w) end,
 	endurance = function () return TReX.stats.endurance_color_percentage(math.floor(TReX.stats.e*100/TReX.stats.maxe))..tostring(TReX.stats.e) end,
 	timestamp = function () timestamp = tostring(getTime(true,"hh:mm:ss:zzz")) return("<dim_grey>"..timestamp) end,
-	rage = function () if not TReX.hunting.rage then TReX.hunting.rage = 0 end return("<dim_grey>(<red>R<white>: "..TReX.hunting.rage.."<dim_grey>)<white>") end,
+	--rage = function () if not TReX.hunting.rage then TReX.hunting.rage = 0 end return("<dim_grey>(<red>R<white>: "..TReX.hunting.rage.."<dim_grey>)<white>") end,
+	rage = function () return("<dim_grey>(<red>R<white>: "..TReX.serverside.myRage() .."<dim_grey>)<white>") end,
 	karma = function () if TReX.s.class=="Occultist" then return "<white>("..TReX.serverside.karma_check()..")%<green> " else return "" end end,
 	sunlight = function () if table.index_of({"Druid","Sylvan"}, TReX.s.class) then if TReX.stats.sunlight >= 1 then return "<white>("..TReX.stats.sunlight..")%<green> " else return "" end else return "" end end,
 	afftracker = function ()


### PR DESCRIPTION
Allows for battlerage prompt to be compatable with other hunting systems. Players have commented that they wish to use their own hunting or not use any hunting systems at all. So this fix should address their need for a battlerage prompt without needing a hunting system.